### PR TITLE
Added optional automated confirmation for backups

### DIFF
--- a/doc/config.sample
+++ b/doc/config.sample
@@ -27,9 +27,8 @@ TRANSFER_DIR=""
 #SERIAL="1234567890ABCDEF"
 # Give you device a name you can understand
 DEVICE_NAME="MyDroid"
-# If you set up encryption for backups enter it here, so
-# automatically confirmed backups will work.
-# Remember, this is plain text!!!
+# If you set up encryption for backups enter your password here, so
+# automatically confirmed backups will work. Remember, this is plain text!!!
 BACKUP_PASSWORD=""
 
 # ---------------------=[ TiBu specifics ]=--
@@ -110,7 +109,8 @@ POSTRUN_CMD=""
 APPNAME_CMD=""
 # If your device is rooted, but the ADB daemon does not run in root mode, set this to 1
 ROOT_COMPAT=0
-# Wether backups should be automatically confirmed via keypresses send with adb (set to 1 to enable)
+# Wether backups should be automatically confirmed via keypresses send with adb
+# (set to 1 to enable)
 AUTO_CONFIRM=1
 
 # ------------=[ Example postrun function ]=--

--- a/doc/config.sample
+++ b/doc/config.sample
@@ -27,6 +27,10 @@ TRANSFER_DIR=""
 #SERIAL="1234567890ABCDEF"
 # Give you device a name you can understand
 DEVICE_NAME="MyDroid"
+# If you set up encryption for backups enter it here, so
+# automatically confirmed backups will work.
+# Remember, this is plain text!!!
+BACKUP_PASSWORD=""
 
 # ---------------------=[ TiBu specifics ]=--
 # IP of the Android device
@@ -106,6 +110,8 @@ POSTRUN_CMD=""
 APPNAME_CMD=""
 # If your device is rooted, but the ADB daemon does not run in root mode, set this to 1
 ROOT_COMPAT=0
+# Wether backups should be automatically confirmed via keypresses send with adb (set to 1 to enable)
+AUTO_CONFIRM=1
 
 # ------------=[ Example postrun function ]=--
 # to avoid possible collisions with functions defined by Adebar itself, use

--- a/doc/config.sample
+++ b/doc/config.sample
@@ -28,7 +28,8 @@ TRANSFER_DIR=""
 # Give you device a name you can understand
 DEVICE_NAME="MyDroid"
 # If you set up encryption for backups enter your password here, so
-# automatically confirmed backups will work. Remember, this is plain text!!!
+# automatically confirmed backups will work.
+# Remember, this is plain text!!! Also: spaces in passwords currently don't work
 BACKUP_PASSWORD=""
 
 # ---------------------=[ TiBu specifics ]=--

--- a/lib/scriptgen.lib
+++ b/lib/scriptgen.lib
@@ -50,6 +50,7 @@ getUserAppBackup() {
   echo "[ ! -d \"${USERDIR}\" ] && mkdir \"${USERDIR}\"" >> "$backupscript"
   echo >> "$backupscript"
   echo "function doBackup() {" >> "$backupscript"
+  echo -e "  echo \"backing up: \${1}\"" >> "$backupscript"
   echo -e "  adb ${ADBOPTS} backup -f \"${USERDIR}/\${1}.ab\" -apk \${1}" >> "$backupscript"
   echo  "  sleep 1" >> "$backupscript" # prevent ADB daemon from being "blocked" (e.g. on LG P880)
   echo "}" >> "$backupscript"
@@ -134,6 +135,7 @@ getSystemAppBackup() {
   echo "[ ! -d \"${SYSDIR}\" ] && mkdir \"${SYSDIR}\"" >> "$backupscript"
   echo >> "$backupscript"
   echo "function doBackup() {" >> "$backupscript"
+  echo -e "  echo \"backing up: \${1}\"" >> "$backupscript"
   echo -e "  adb ${ADBOPTS} backup -f \"${SYSDIR}/\${1}.ab\" -noapk \${1}" >> "$backupscript"
   echo  "  sleep 1" >> "$backupscript" # prevent ADB daemon from being "blocked" (e.g. on LG P880)
   echo "}" >> "$backupscript"

--- a/lib/scriptgen.lib
+++ b/lib/scriptgen.lib
@@ -55,6 +55,30 @@ getUserAppBackup() {
   echo "}" >> "$backupscript"
   echo >> "$backupscript"
 
+  if [[ "${AUTO_CONFIRM}" -eq 1 ]]; then
+      echo "function autoConfirm() {" >> "$backupscript"
+      if [[ ! -z "${BACKUP_PASSWORD}" ]]; then
+          echo -e "    adb ${ADBOPTS} shell input text \"${BACKUP_PASSWORD}\" \\" >> "$backupscript"
+          echo    "    && sleep 1" >> "$backupscript" # wait between sending text and keycodes
+      fi
+      echo -e "    adb ${ADBOPTS} shell input keyevent 22 \\" >> "$backupscript"
+      echo    "    && sleep 1 \\" >> "$backupscript" # wait between keycodes
+      echo -e "    && adb ${ADBOPTS} shell input keyevent 23" >> "$backupscript"
+      echo "}" >> "$backupscript"
+      echo >> "$backupscript"
+      echo    "function autoConfirmedBackup() {" >> "$backupscript"
+      echo -e "    doBackup \"\${1}\" &" >> "$backupscript"
+      echo -e "    JOB=\$!" >> "$backupscript"
+      echo -e "    sleep 1" >> "$backupscript"
+      echo -e "    autoConfirm" >> "$backupscript"
+      echo -e "    while [[ \$? == 0 ]]; do" >> "$backupscript"
+      echo -e "        sleep 1" >> "$backupscript"
+      echo -e "        ps -p \${JOB} &>/dev/null" >> "$backupscript"
+      echo -e "    done" >> "$backupscript"
+      echo -e "}" >> "$backupscript"
+      echo >> "$backupscript"
+  fi
+
   echo "#!/bin/bash" > "$restorescript"
   echo "# Restore script from ${DEVICE_NAME} as of $(date '+%Y-%m-%d %H:%M')" >> "$restorescript"
   echo "# Restores all app backups. Comment out (or delete) those you do not wish to restore." >> "$restorescript"
@@ -80,7 +104,11 @@ getUserAppBackup() {
   echo  >> "$restorescript"
 
   for app in "${userApps[@]}"; do
-    echo "doBackup ${app}" >> "$backupscript"
+    if [[ "${AUTO_CONFIRM}" -eq 1 ]]; then
+        echo "autoConfirmedBackup ${app}" >> "$backupscript"
+    else
+        echo "doBackup ${app}" >> "$backupscript"
+    fi
     echo -e "doRestore \"${USERDIR}/${app}.ab\"" >> "$restorescript"
   done
 
@@ -110,6 +138,31 @@ getSystemAppBackup() {
   echo  "  sleep 1" >> "$backupscript" # prevent ADB daemon from being "blocked" (e.g. on LG P880)
   echo "}" >> "$backupscript"
   echo >> "$backupscript"
+
+  if [[ "${AUTO_CONFIRM}" -eq 1 ]]; then
+      echo "function autoConfirm() {" >> "$backupscript"
+          if [[ ! -z "${BACKUP_PASSWORD}" ]]; then
+              echo -e "    adb ${ADBOPTS} shell input text \"${BACKUP_PASSWORD}\" \\" >> "$backupscript"
+              echo    "    && sleep 1" >> "$backupscript" # wait between sending text and keycodes
+          fi
+          echo -e "    adb ${ADBOPTS} shell input keyevent 22 \\" >> "$backupscript"
+          echo    "    && sleep 1 \\" >> "$backupscript" # wait between keycodes
+          echo -e "    && adb ${ADBOPTS} shell input keyevent 23" >> "$backupscript"
+      echo "}" >> "$backupscript"
+      echo >> "$backupscript"
+      echo    "function autoConfirmedBackup() {" >> "$backupscript"
+      echo -e "    doBackup \"\${1}\" &" >> "$backupscript"
+      echo -e "    JOB=\$!" >> "$backupscript"
+      echo -e "    sleep 1" >> "$backupscript"
+      echo -e "    autoConfirm" >> "$backupscript"
+      echo -e "    while [[ \$? == 0 ]]; do" >> "$backupscript"
+      echo -e "        sleep 1" >> "$backupscript"
+      echo -e "        ps -p \${JOB} &>/dev/null" >> "$backupscript"
+      echo -e "    done" >> "$backupscript"
+      echo -e "}" >> "$backupscript"
+      echo >> "$backupscript"
+  fi
+
 
   echo "#!/bin/bash" > "$restorescript"
   echo "# Restore script from ${DEVICE_NAME} as of $(date '+%Y-%m-%d %H:%M')" >> "$restorescript"
@@ -148,7 +201,13 @@ getSystemAppBackup() {
     else
       prep=""
     fi
-    echo "${prep}doBackup ${app}" >> "$backupscript"
+
+    if [[ "${AUTO_CONFIRM}" -eq 1 ]]; then
+        echo "${prep}autoConfirmedBackup ${app}" >> "$backupscript"
+    else
+        echo "${prep}doBackup ${app}" >> "$backupscript"
+    fi
+
     echo -e "${prep}doRestore \"${SYSDIR}/${app}.ab\"" >> "$restorescript"
     if [ "$app" = "com.android.sharedstoragebackup" ]; then
       echo -e "else\n  echo \"Skipping shared storage\"\nfi" >> "$backupscript"


### PR DESCRIPTION
- I implemented optional automated confirmation for backups.
- Adebar's backup function wil be running in the background, so confirmation keycodes can be sent.
- I tested the script-generation and the resulting script and they both work.
- Also I tried to follow the Adebar coding-style, if you have any suggestions, tell me
- I think this ability is very important and adds greatly to the usability of Adebar
