### PR TITLE
Correcting default behavior on restore.

### DIFF
--- a/lib/scriptgen.lib
+++ b/lib/scriptgen.lib
@@ -93,7 +93,7 @@ getUserAppBackup() {
   if [[ "${MK_APPRESTORE_DELAY,,}" = "p" ]]; then
     echo "  read -n 1 -p \"Do you wish to restore \${1#*/} now? (Y/n) \" res" >> "$restorescript"
     echo "  echo" >> "$restorescript"
-    echo "  if [ \"\${res,,}\" = \"y\" ]; then" >> "$restorescript"
+    echo "  if [[ \"\${res,,}\" = \"y\" || -z \"\${res}\" ]]; then" >> "$restorescript"
     echo -e "  echo \"restoring: \${1}\"" >> "$restorescript"
     echo "    adb ${ADBOPTS} restore \${1}" >> "$restorescript"
     echo "  else" >> "$restorescript"
@@ -230,7 +230,7 @@ getSystemAppBackup() {
   if [[ "${MK_APPRESTORE_DELAY,,}" = "p" ]]; then
     echo "  read -n 1 -p \"Do you wish to restore \${1#*/} now? (Y/n) \" res" >> "$restorescript"
     echo "  echo" >> "$restorescript"
-    echo "  if [ \"\${res,,}\" = \"y\" ]; then" >> "$restorescript"
+    echo "  if [[ \"\${res,,}\" = \"y\" || -z \"\${res}\" ]]; then" >> "$restorescript"
     echo -e "  echo \"restoring: \${1}\"" >> "$restorescript"
     echo "    adb ${ADBOPTS} restore \${1}" >> "$restorescript"
     echo "  else" >> "$restorescript"

--- a/lib/scriptgen.lib
+++ b/lib/scriptgen.lib
@@ -282,8 +282,8 @@ getSystemAppBackup() {
       echo  >> "$restorescript"
       echo -e "echo \"The following command will download 'shared storage' (i.e. contents of the SD card(s)).\"\necho \"This might take quite a while, depending on what you've stored there.\"" >> "$backupscript"
       echo -e "echo \"The following command will restore 'shared storage' (i.e. contents of the SD card(s)).\"\necho \"This might take quite a while, depending on how big your backup from it was.\"" >> "$restorescript"
-      echo -e "read -n 1 -p \"Do you wish to run this command now? (Y/n) \" res\necho\nif [ \"\${res,,}\" = \"y\" ]; then" >> "$backupscript"
-      echo -e "read -n 1 -p \"Do you wish to run this command now? (Y/n) \" res\necho\nif [ \"\${res,,}\" = \"y\" ]; then" >> "$restorescript"
+      echo -e "read -n 1 -p \"Do you wish to run this command now? (Y/n) \" res\necho\nif [[ \"\${res,,}\" = \"y\" || -z \"\${res}\" ]]; then" >> "$backupscript"
+      echo -e "read -n 1 -p \"Do you wish to run this command now? (Y/n) \" res\necho\nif [[ \"\${res,,}\" = \"y\" || -z \"\${res}\" ]]; then" >> "$restorescript"
     else
       prep=""
     fi


### PR DESCRIPTION
In current implementation, even though "Y" option is being suggested to be default on restore question, when no input is given, restore is being skipped like there was "n" given.
