### PR TITLE
Env bash

### DIFF
--- a/adebar-cli
+++ b/adebar-cli
@@ -80,6 +80,7 @@ ROOT_COMPAT=0
 ROOT_PMDISABLE=0
 AUTO_CONFIRM=0
 AUTO_UNLOCK=0
+BASH_LOCATION="/usr/bin/env bash"
 
 # Internal use / debugging
 _OOPS_LEVEL_ADJUST=0 # 0=no_adjust; increase to "hide" oopses, decrease to force them to be revealed even on lower levels

--- a/adebar-cli
+++ b/adebar-cli
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Adebar
 # (Android DEvice Backup And Restore)
 # Creating scripts to backup and restore your apps, settings, and more

--- a/lib/deviceinfo.lib
+++ b/lib/deviceinfo.lib
@@ -1,4 +1,3 @@
-#!/bin/bash
 ##############################################################################
 # Adebar © 2014, 2015 by Itzchak Rehberg
 # This is part of the Adebar project, see https://github.com/IzzySoft/Adebar

--- a/lib/packagedata.lib
+++ b/lib/packagedata.lib
@@ -1,4 +1,3 @@
-#!/bin/bash
 ##############################################################################
 # Adebar © 2014, 2015 by Itzchak Rehberg
 # This is part of the Adebar project, see https://github.com/IzzySoft/Adebar

--- a/lib/packagedata.lib
+++ b/lib/packagedata.lib
@@ -358,7 +358,7 @@ getAppDetails() {
   done < "${PKGDUMP}"
 
   getAppUsage
-  echo -e "#!/bin/bash" > "${SH_DISABLED}"
+  echo -e "#!${BASH_LOCATION}" > "${SH_DISABLED}"
 
   [[ ${MK_USERAPPS} -ne 0 ]] && _makeAppDoc "user"
   [[ ${MK_SYSAPPS}  -ne 0 ]] && _makeAppDoc "system"

--- a/lib/partitions.lib
+++ b/lib/partitions.lib
@@ -1,4 +1,3 @@
-#!/bin/bash
 ##############################################################################
 # Adebar © 2014, 2015 by Itzchak Rehberg
 # This is part of the Adebar project, see https://github.com/IzzySoft/Adebar

--- a/lib/partitions.lib
+++ b/lib/partitions.lib
@@ -164,7 +164,7 @@ _fsProcPart() {
 _fsPartBackup() {
   [[ ${MK_PARTBACKUP} -eq 0 ]] && return
   declare -i counter=0
-  echo "#!/bin/bash" > "${PARTBACKUP_FILE}"
+  echo "#!${BASH_LOCATION}" > "${PARTBACKUP_FILE}"
   echo "# extract images for ${DEVICE_NAME} (created at $(date '+%Y-%m-%d %H:%M'))" >> "${PARTBACKUP_FILE}"
   echo "# WARNING! Use those images at your own risk – especially when considering a restore." >> "${PARTBACKUP_FILE}"
   echo "# Some might contain a file system you could mount, others just 'raw data'." >> "${PARTBACKUP_FILE}"

--- a/lib/pull_config.lib
+++ b/lib/pull_config.lib
@@ -1,4 +1,3 @@
-#!/bin/bash
 ##############################################################################
 # Adebar © 2014, 2015 by Itzchak Rehberg
 # This is part of the Adebar project, see https://github.com/IzzySoft/Adebar

--- a/lib/scriptgen.lib
+++ b/lib/scriptgen.lib
@@ -1,4 +1,3 @@
-#!/bin/bash
 ##############################################################################
 # Adebar © 2014, 2015 by Itzchak Rehberg
 # This is part of the Adebar project, see https://github.com/IzzySoft/Adebar

--- a/lib/scriptgen.lib
+++ b/lib/scriptgen.lib
@@ -16,7 +16,7 @@ getDisabled() {
   doProgress "Obtaining list of disabled apps"
 
   local scriptname="${OUTDIR}/disable"
-  echo "#!/bin/bash" > "${scriptname}"
+  echo "#!${BASH_LOCATION}" > "${scriptname}"
   echo "# Disabled apps for ${DEVICE_NAME} as of $(date '+%Y-%m-%d %H:%M')" >> "${scriptname}"
   echo >> "${scriptname}"
 
@@ -44,7 +44,7 @@ getEnable() {
   doProgress "Creating script to enable ALL apps"
 
   local scriptname="${OUTDIR}/enable"
-  echo "#!/bin/bash" > "${scriptname}"
+  echo "#!${BASH_LOCATION}" > "${scriptname}"
   echo "# Enable ALL apps on the device" >> "${scriptname}"
   echo "#" >> "${scriptname}"
   echo "# Use with care – some apps might be disabled for a good reason :)" >> "${scriptname}"
@@ -75,7 +75,7 @@ getUserAppBackup() {
 
   local backupscript="$OUTDIR/userbackup"
   local restorescript="$OUTDIR/userrestore"
-  echo "#!/bin/bash" > "$backupscript"
+  echo "#!${BASH_LOCATION}" > "$backupscript"
   echo "# Backup script for ${DEVICE_NAME} as of $(date '+%Y-%m-%d %H:%M')" >> "$backupscript"
   echo "# Backs up all user apps including their .apk files and data" >> "$backupscript"
   echo "# Feel free to comment out/remove apps you don't want/need to be backed up." >> "$backupscript"
@@ -116,7 +116,7 @@ getUserAppBackup() {
       echo >> "$backupscript"
   fi
 
-  echo "#!/bin/bash" > "$restorescript"
+  echo "#!${BASH_LOCATION}" > "$restorescript"
   echo "# Restore script from ${DEVICE_NAME} as of $(date '+%Y-%m-%d %H:%M')" >> "$restorescript"
   echo "# Restores all app backups. Comment out (or delete) those you do not wish to restore." >> "$restorescript"
   echo  >> "$restorescript"
@@ -214,7 +214,7 @@ getSystemAppBackup() {
 
   local backupscript="$OUTDIR/sysbackup"
   local restorescript="$OUTDIR/sysrestore"
-  echo "#!/bin/bash" > "$backupscript"
+  echo "#!${BASH_LOCATION}" > "$backupscript"
   echo "# Backup script for ${DEVICE_NAME} as of $(date '+%Y-%m-%d %H:%M')" >> "$backupscript"
   echo "# Backs up the data (not the .apk files) of all your system apps" >> "$backupscript"
   echo "# Feel free to comment out/remove apps you don't want/need to be backed up." >> "$backupscript"
@@ -253,7 +253,7 @@ getSystemAppBackup() {
       echo >> "$backupscript"
   fi
 
-  echo "#!/bin/bash" > "$restorescript"
+  echo "#!${BASH_LOCATION}" > "$restorescript"
   echo "# Restore script from ${DEVICE_NAME} as of $(date '+%Y-%m-%d %H:%M')" >> "$restorescript"
   echo -e "# Restores all system app data backups.\n# DRAGONS HERE: this might fail if you restore to a different\n# device/Android version/ROM, so be careful!\n# Comment out/delete what you do not wish to restore." >> "$restorescript"
   echo  >> "$restorescript"
@@ -355,7 +355,7 @@ getInstallLoc() {
   [[ $MK_INSTALLLOC -ne 1 ]] && return
   doProgress "Checking default install-location"
   foo="$(adb ${ADBOPTS} shell pm get-install-location)"
-  echo "#!/bin/bash" > "$OUTDIR/defaultInstallLoc"
+  echo "#!${BASH_LOCATION}" > "$OUTDIR/defaultInstallLoc"
   echo "# Set default install location for apps (taken from ${DEVICE_NAME} at $(date '+%Y-%m-%d %H:%M'))" >> "$OUTDIR/defaultInstallLoc"
   echo "pm set-install-location ${foo//[^0-9]/}" >> "$OUTDIR/defaultInstallLoc"
   chmod u+x "$OUTDIR/defaultInstallLoc"

--- a/lib/tibu.lib
+++ b/lib/tibu.lib
@@ -1,4 +1,3 @@
-#!/bin/bash
 ##############################################################################
 # Adebar © 2014, 2015 by Itzchak Rehberg
 # This is part of the Adebar project, see https://github.com/IzzySoft/Adebar

--- a/lib/tibu.lib
+++ b/lib/tibu.lib
@@ -16,7 +16,7 @@ getTibu() {
   doProgress "Creating scripts to pull stuff from ${DEVICE_NAME} via TiBu"
 
   local scriptname="${OUTDIR}/tibu"
-  echo "#!/bin/bash" > "${scriptname}"
+  echo "#!${BASH_LOCATION}" > "${scriptname}"
   echo "# Download contents of external/internal SDCard and Backups via TitaniumBackups WebServer" >> "${scriptname}"
   echo "# Make sure your device is connected to your local WiFi, and you've enabled TiBu's WebServer" >> "${scriptname}"
   echo "# The latter can be done from within TiBu via the menu" >> "${scriptname}"

--- a/lib/transfer.lib
+++ b/lib/transfer.lib
@@ -1,4 +1,3 @@
-#!/bin/bash
 ##############################################################################
 # Adebar © 2014, 2015 by Itzchak Rehberg
 # This is part of the Adebar project, see https://github.com/IzzySoft/Adebar

--- a/tools/ab2tar
+++ b/tools/ab2tar
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # convert ADB Backups to tar
 
 [[ -z "$1" ]] && {

--- a/tools/getPkgData.php
+++ b/tools/getPkgData.php
@@ -38,7 +38,7 @@ $result = xml2array($contents,1,'attribute');
  */
 function disabledComponents($result,$mdfile,$adbfile) {
   $md = '';
-  $adb = "#!/bin/bash\n# Disable Components\n\n";
+  $adb = "#!/usr/bin/env bash\n# Disable Components\n\n";
   foreach($result['packages']['package'] as $key => $package) {
     if ( !isset($package['attr']['name']) ) continue;
     $name = $package['attr']['name'];


### PR DESCRIPTION
As per https://github.com/d5ve/Adebar/commit/82f23b8df6c93f25fa0dd426c2bb588aa931a6a9#commitcomment-18548205

OSX has a very old version of bash, 3.2.57, from 2007 which doesn't support some of the scripts used by Adebar.

Changing to use `#!/usr/bin/env bash` instead of `#!/bin/bash` allows users to install newer versions of bash (via homebrew or macports) and use them instead.
